### PR TITLE
Release (#505)

### DIFF
--- a/PetaPoco.Tests.Unit/DatabaseTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseTests.cs
@@ -11,7 +11,9 @@ using System.Data.SqlClient;
 using System.Dynamic;
 using Moq;
 using PetaPoco.Core;
+using PetaPoco.Providers;
 using PetaPoco.Tests.Unit.Models;
+using PetaPoco.Utilities;
 using Shouldly;
 using Xunit;
 
@@ -95,6 +97,7 @@ namespace PetaPoco.Tests.Unit
                     throw;
                 }
             });
+            Should.Throw<ArgumentException>(() => new Database<SqlServerDatabaseProvider>(null));
         }
 
         [Fact]
@@ -252,6 +255,6 @@ namespace PetaPoco.Tests.Unit
 
                 return null;
             }
-        }
+        }        
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -72,8 +72,9 @@ namespace PetaPoco
         /// <summary>
         ///     Constructs an instance using the first connection string found in the app/web configuration file.
         /// </summary>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="InvalidOperationException">Thrown when no connection strings can registered.</exception>
-        public Database()
+        public Database(IMapper defaultMapper = null)
         {
             if (ConfigurationManager.ConnectionStrings.Count == 0)
                 throw new InvalidOperationException("One or more connection strings must be registered to use the no paramater constructor");
@@ -81,7 +82,7 @@ namespace PetaPoco
             var entry = ConfigurationManager.ConnectionStrings[0];
             _connectionString = entry.ConnectionString;
             var providerName = !string.IsNullOrEmpty(entry.ProviderName) ? entry.ProviderName : "System.Data.SqlClient";
-            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -89,9 +90,10 @@ namespace PetaPoco
         ///     read from app/web.config.
         /// </summary>
         /// <param name="connectionStringName">The name of the connection.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionStringName" /> is null or empty.</exception>
         /// <exception cref="InvalidOperationException">Thrown when a connection string cannot be found.</exception>
-        public Database(string connectionStringName)
+        public Database(string connectionStringName, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionStringName))
                 throw new ArgumentException("Connection string name must not be null or empty", nameof(connectionStringName));
@@ -103,7 +105,7 @@ namespace PetaPoco
 
             _connectionString = entry.ConnectionString;
             var providerName = !string.IsNullOrEmpty(entry.ProviderName) ? entry.ProviderName : "System.Data.SqlClient";
-            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), defaultMapper);
         }
 #endif
 
@@ -129,21 +131,22 @@ namespace PetaPoco
         }
 
         /// <summary>
-        ///     Constructs an instance using a supplied connections string and provider name.
+        ///     Constructs an instance using a supplied connection string and provider name.
         /// </summary>
         /// <param name="connectionString">The database connection string.</param>
         /// <param name="providerName">The database provider name.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <remarks>
         ///     PetaPoco will automatically close and dispose any connections it creates.
         /// </remarks>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
-        public Database(string connectionString, string providerName)
+        public Database(string connectionString, string providerName, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Connection string cannot be null or empty", nameof(connectionString));
 
             _connectionString = connectionString;
-            Initialise(DatabaseProvider.Resolve(providerName, true, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, true, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -151,9 +154,10 @@ namespace PetaPoco
         /// </summary>
         /// <param name="connectionString">The database connection string.</param>
         /// <param name="factory">The DbProviderFactory to use for instantiating IDbConnection's.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory" /> is null.</exception>
-        public Database(string connectionString, DbProviderFactory factory)
+        public Database(string connectionString, DbProviderFactory factory, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Connection string must not be null or empty", nameof(connectionString));
@@ -162,7 +166,7 @@ namespace PetaPoco
                 throw new ArgumentNullException(nameof(factory));
 
             _connectionString = connectionString;
-            Initialise(DatabaseProvider.Resolve(DatabaseProvider.Unwrap(factory).GetType(), false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(DatabaseProvider.Unwrap(factory).GetType(), false, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -2860,5 +2864,19 @@ namespace PetaPoco
         /// </summary>
         public event EventHandler<ExceptionEventArgs> ExceptionThrown;
         #endregion
+    }
+
+    public class Database<TDatabaseProvider> : Database where TDatabaseProvider : IProvider
+    {
+        /// <summary>
+        /// Constructs an instance using a supplied connection string and provider type.
+        /// </summary>
+        /// <param name="connectionString">The database connection string.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
+        public Database(string connectionString, IMapper defaultMapper = null)
+            : base(connectionString, typeof(TDatabaseProvider).Name, defaultMapper)
+        {
+        }
     }
 }

--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,8 @@ PetaPoco is available from:
 ## Add-ons
 
 * [PetaPoco.SqlKata](//github.com/asherber/PetaPoco.SqlKata) lets you use the powerful query builder [SqlKata](//sqlkata.com)  to [build SQL queries](//github.com/CollaboratingPlatypus/PetaPoco/wiki/Building-SQL-Queries) for PetaPoco.
+* [StaTypPocoQueries.PetaPoco](//github.com/asherber/StaTypPocoQueries.PetaPoco) provides the ability to use some simple, strongly typed, Intellisensed LINQ expressions in your queries.
+
 
 ## Contributing
 


### PR DESCRIPTION
* Update README.markdown

* Fix appveyor build

  - Proabably won't fix it :/

* Add IncludeInAutoSelect param to ResultColumnAttribute

* Add unit tests

* Generate a SELECT for Single<T> even if EnableAutoSelect is false

* Update README.md

Added add-ons section, with reference to PetaPoco.SqlKata

* Teach IsNew() about decimal primary key

* Add overloads without sql param

Give Fetch(), Query(), Page(), and SkipTake() overloads that omit the
string sql parameter, so that PetaPoco will do SELECT *

* Update README.markdown

* First pass

* Move SetParameterProperties back to Database

* Factor out ExecuteReader

* Add FetchProc

* Add ExecuteScalarProc

* Add ExecuteNonQueryProc

* Add interface

* Add unit tests

* Set CommandText after processing params

* Refactor param prefix regexes

* Add SQL Server integration tests

Had to refactor MssqlDBTestProvider in order to
get CREATE PROCEDURE to run in the right database

* Add MySql and MariaDb integration tests

* Add integration tests with IDataParameter

* Add Postgres integration tests

* Add Firebird integration tests

* Fix EnsureParamPrefix

* Remove extra Usings

* Better handling of enumerable args

* Allow for an IDbDataParameter to be added directly to Sql

* Add events

* Add fluent configuration for events

* Revert "Allow for an IDbDataParameter to be added directly to Sql"

This reverts commit 21d31fc63ff715e506d215c2b148f093887acb01.

* Add xml doc for fluent config

* Fix version not applied to assemblies

* Fix version not applied to assemblies

* Update README

Add StaTypPocoQueries.PetaPoco

* Delete testing file

* Add generic db constructor, and add optional mapper to all